### PR TITLE
disp/ new about paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,28 @@
 
     .mobile_about_container { max-width: var(--content-max); margin-inline: auto; padding-inline: var(--content-pad); }
     .mobile_about_header { text-align: left; font-size: 1.5rem; font-weight: 700; padding-left: .25rem; margin-top: 1rem; }
-    .mobile_about_paragraph { line-height: 1.7; margin: 1rem 0 2rem; }
+    .mobile_about_paragraph { max-width: 760px; font-family: 'Playfair Display', serif; line-height: 1.65; margin: 1rem 0 2rem; }
+    .mobile_about_paragraph, .mobile_about_paragraph b { font-family: 'Playfair Display', serif; }
+    .mobile_about_paragraph {
+      margin-top: 1.5rem;
+      margin-bottom: 3rem;
+    } 
+
+    .mobile_about_paragraph {
+      /* font-size: clamp(1.15rem, 4.8vw, 1.55rem); */
+      font-size: clamp(1rem, 3.5vw, 1.3rem);
+      line-height: 1.55;
+    }
+
+    @media (max-width: 480px) {
+      .mobile_about_paragraph {
+        font-size: clamp(1.15rem, 4.6vw, 1.55rem);
+        line-height: 1.5;
+      }
+    }
+
+    
+    
 
     /* COLLECTIONS */
     #collections { max-width: var(--content-max); margin-inline: auto; padding-inline: var(--content-pad); }
@@ -478,6 +499,10 @@
   opacity: 1;
 }
 
+#mobile-about-divider {
+      margin-top: 2.5rem;
+    }
+
 /* --- Footer icon glow (Dream Agent) --- */
 .footer-icons .icon-wrap {
   position: relative;
@@ -685,14 +710,19 @@
     <!-- ABOUT -->
     <section id="mobile_about" class="mobile_about">
       <div class="mobile_about_container py-8">
-        <h1 class="mobile_about_header">Who is Dream Agent?</h1>
 
-         <!-- short intro + read more -->
-        <p class="mobile_about_portion mt-2">An anonymous digital artist emerging from the shadows of the digital realm, not as a face but as a surrealist force.... <button class="read_more"><b>Read More</b></button></p>
+        <!-- --------------------------------------------------------------------------------------- -->
+        <!-- --------------------------------------------------------------------------------------- -->
+        <!-- --------------------------------------------------------------------------------------- -->
+        <!-- <h1 class="mobile_about_header">Who is Dream Agent?</h1> -->
 
-        <p class="mobile_about_paragraph hidden">
-          An anonymous digital artist emerging from the shadows of the digital realm, not as a face but as a surrealist force. Each work transforms digital vision into symbolic worlds, less an image than a portal, inviting viewers to question, decode, and reflect.
+        <p class="mobile_about_paragraph">
+          <b>Dream Agent</b> is a recording mechanism that traverses dreamlike systems, capturing the moments where structure becomes visible.
         </p>
+
+        <!-- --------------------------------------------------------------------------------------- -->
+        <!-- --------------------------------------------------------------------------------------- -->
+        <!-- --------------------------------------------------------------------------------------- -->
 
         <!-- Divider -->
         <div id="mobile-about-divider" class="w-40 sm:w-56 h-[2px] bg-white/30 mx-auto my-6 sm:my-10 lg:my-12 rounded-full shadow-[0_0_8px_rgba(255,255,255,0.4)] opacity-0 scale-x-0 transition-transform duration-700 ease-out"></div>


### PR DESCRIPTION
Eliminated the About section header because the new about section paragraph is descriptive enough,
Enter a system header is restyled to now match the texture of the arrow buttons