### PR TITLE
Disp/new slide in menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,23 @@
       outline-offset: 2px;
     }
 
+    /* Subtle CourDevelops signature styling */
+    #siteDrawer .courdevelops-signature a {
+      opacity: 0.72;
+      font-size: 0.82rem;
+      transition: opacity 200ms ease;
+    }
+
+    #siteDrawer .courdevelops-signature img {
+      width: 19px;
+      height: 19px;
+      opacity: 0.72;
+    }
+
+    #siteDrawer .courdevelops-signature a:hover {
+      opacity: 0.92;
+    }
+
     /* Prevent background scroll while menu is open */
     html.has-drawer { overflow: hidden; }
 
@@ -954,8 +971,7 @@
         aria-hidden="true">
     <div class="flex items-center justify-between px-4 py-4 border-b border-white/10">
       <div class="flex items-center gap-3">
-        <img src="img/icons/artist/dream_agent_logo_blue.png" alt="dream_agent" class="w-9 h-9 rounded-full border border-white/10"/>
-        <span class="text-white/90 font-bold" style="font-family: 'Playfair Display', serif;">Dream Agent</span>
+        <img src="img/icons/artist/dream_agent_logo_blue.png" alt="dream_agent" class="w-12 h-12 rounded-full border border-white/10"/>
       </div>
       <button id="closeDrawer"
               class="w-10 h-10 grid place-items-center rounded-full bg-white/10 border border-white/20 hover:bg-white/20 transition"
@@ -1023,7 +1039,7 @@
       </ul>
     </nav>
 
-    <div class="mt-auto px-4 py-4 border-t border-white/8">
+    <div class="mt-auto px-4 py-4 border-t border-white/8 courdevelops-signature">
   <a href="https://courdevelops.com"
      target="_blank"
      rel="noopener"

--- a/index.html
+++ b/index.html
@@ -48,6 +48,63 @@
     .drawer-open #siteDrawer { transform: translateX(0); }
     .drawer-open #drawerOverlay { opacity: 1; pointer-events: auto; }
 
+    /* Slide-in menu visual style */
+    #siteDrawer {
+      background-image:
+        radial-gradient(circle at 18% 18%, rgba(106, 150, 232, 0.09), transparent 20%),
+        radial-gradient(circle at 82% 88%, rgba(0, 0, 0, 0.18), transparent 28%),
+        radial-gradient(circle at 50% 25%, rgba(255, 255, 255, 0.03), transparent 22%),
+        linear-gradient(to bottom, rgba(8,28,64,0.90), rgba(3,18,45,0.88));
+      background-repeat: no-repeat;
+      background-size: cover;
+      -webkit-backdrop-filter: blur(10px);
+      backdrop-filter: blur(10px);
+    }
+
+    /* Subtle drawer-only divider tones */
+    #siteDrawer .border-white\/10,
+    #siteDrawer .border-white\/20,
+    #siteDrawer .border-white\/8 {
+      border-color: rgba(255, 255, 255, 0.12) !important;
+    }
+
+    /* Minimal close control for the slide-in menu */
+    #siteDrawer #closeDrawer {
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0;
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      border-radius: 0 !important;
+      color: rgba(255, 255, 255, 0.92);
+      display: grid;
+      place-items: center;
+      opacity: 0.92;
+      transition: opacity 200ms ease;
+    }
+
+    #siteDrawer #closeDrawer svg {
+      width: 28px;
+      height: 28px;
+    }
+
+    #siteDrawer #closeDrawer svg path {
+      stroke: currentColor !important;
+    }
+
+    #siteDrawer #closeDrawer:hover,
+    #siteDrawer #closeDrawer:focus-visible {
+      opacity: 1;
+    }
+
+    #siteDrawer #closeDrawer:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.18);
+      outline-offset: 2px;
+    }
+
     /* Prevent background scroll while menu is open */
     html.has-drawer { overflow: hidden; }
 


### PR DESCRIPTION
# UI Refinement · Mobile Slide-In Menu

## Summary

Refined the mobile slide-in navigation to better match the Dream Agent aesthetic while keeping the interface simple, understated, and gallery-like.

## Changes

### ✨ Menu Atmosphere

- Added a subtle vertical gradient to the slide-in menu background.
- Reduced background opacity to approximately 85–90%.
- Applied a `backdrop-filter: blur(10px)` effect for a frosted-glass appearance.
- Preserved readability by keeping navigation text and icons fully opaque.

### 🎨 Visual Depth

- Added a very subtle blue vignette using layered CSS gradients.
- Introduced gentle atmospheric depth without adding distracting textures or patterns.
- Kept the effect intentionally understated so it complements the artwork rather than competing with it.

### ➖ Divider Refinements

- Reduced divider contrast to create quieter visual separation.

```css
border-color: rgba(255, 255, 255, 0.12);
```

- Preserved existing spacing and layout.

### ✖️ Close Control

- Replaced the "Close" button with a minimalist × icon.
- Removed button background, border, shadow, and glow.
- Maintained a minimum 44×44px invisible tap target for accessibility.
- Added a subtle fade transition for hover and tap states.
- Preserved existing close functionality.

### 🎭 Branding

- Removed the "Dream Agent" text from the menu header.
- Increased the logo size by approximately 20–30%.
- Preserved the existing left alignment to maintain visual consistency with the navigation.

### 🖋️ Footer Signature

- Reduced the CourDevelops logo size.
- Lowered the opacity of the logo and text to approximately 70%.
- Slightly reduced the font size.
- Preserved the existing layout and positioning.
- Kept hover interactions subtle.

## Result

The mobile navigation now feels more cohesive with the Dream Agent experience by emphasizing simplicity, atmosphere, and hierarchy. The interface recedes into the background, allowing the artwork and brand identity to remain the primary focus.